### PR TITLE
changed bold to shadow to address bug in firefox

### DIFF
--- a/tcresearch.css
+++ b/tcresearch.css
@@ -24,7 +24,7 @@
 .aspectlist > li.aspect:hover {
 	background:#DDD;
 	color:#000;
-	font-weight:bold;
+	text-shadow:1px 0px 0px black;
 }
 #avail > li {
 	width:25%;
@@ -37,7 +37,7 @@
 }
 .aspect .desc {
 	overflow: hidden;
-	font-weight:normal;
+	text-shadow:0px 0px 0px black;
 	line-height: 1.4em;
 	font-size:small;
 }


### PR DESCRIPTION
![shifting](https://cloud.githubusercontent.com/assets/5581459/7269814/df9c66a4-e88b-11e4-969f-4fa7bd4326ed.png)

In Firefox, when hovering over elements, all elements below it were being shifted to the right. I changed the bold effect to a shadow effect which appears very similar, but doesn't change the actual size of the text (which was causing the shifting).
