### PR TITLE
Use scheme-relative url for external resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
 	<meta charset="UTF-8">
 	<title>Thaumcraft 4.x Research Helper</title>
 	<script type="text/javascript" src="buckets-minified.js"></script>
-	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
-	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
+	<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+	<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
 	<script type="text/javascript" src="select2.min.js"></script>
-	<link rel="stylesheet" href="http://code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css">
+	<link rel="stylesheet" href="//code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css">
 	<link rel="stylesheet" href="select2.css">
 	<script type="text/javascript" src="translation_dictionary.js"></script>
 	<script type="text/javascript" src="version_dictionary.js"></script>


### PR DESCRIPTION
This eliminates mixed content error on newer versions of Chrome.
