### PR TITLE
Update css ref to use SSL

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
 	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
 	<script type="text/javascript" src="select2.min.js"></script>
-	<link rel="stylesheet" href="http://code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css">
+	<link rel="stylesheet" href="https://code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css">
 	<link rel="stylesheet" href="select2.css">
 	<script type="text/javascript" src="translation_dictionary.js"></script>
 	<script type="text/javascript" src="version_dictionary.js"></script>


### PR DESCRIPTION
Chrome blocks non-https refs from https sites and github is serving github pages with SSL now.
